### PR TITLE
Update docs builder to latest version of Sphinx.

### DIFF
--- a/docs/custom_html_writer.py
+++ b/docs/custom_html_writer.py
@@ -19,7 +19,7 @@ how to write a custom Sphinx extension.
 """
 
 from sphinx import errors
-from sphinx.writers import html
+from sphinx.builders import html
 
 
 _LITERAL_ERR_TEMPLATE = """\
@@ -33,7 +33,7 @@ are not allowed.
 """
 
 
-class CustomHTMLWriter(html.SmartyPantsHTMLTranslator):
+class CustomHTMLWriter(html.HTML5Translator):
     """Custom HTML writer.
 
     This makes sure that code blocks are all tested. It does this by

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
+sphinx
 sphinx-docstring-typing
+sphinx_rtd_theme


### PR DESCRIPTION
SmartyPantsHTMLTranslator was removed. Also, writers were moved to
builders.

I also added Sphinx and the RTD theme to docs/requirements.txt (I did
also see them in `tox.ini`, but I'm used to installing the
requirements.txt files for developments.)